### PR TITLE
Improve setup.py

### DIFF
--- a/googletrans/__init__.py
+++ b/googletrans/__init__.py
@@ -1,7 +1,6 @@
 """Free Google Translate API for Python. Translates totally free of charge."""
 __all__ = 'Translator',
-__version_info__ = 2, 1, 2
-__version__ = '.'.join(str(v) for v in __version_info__)
+__version__ = '2.1.2'
 
 
 from googletrans.client import Translator

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import googletrans
 import os.path
+import re
+
 from setuptools import setup, find_packages
 
 
-def readme():
-    path = os.path.join(os.path.dirname(__file__), 'README.rst')
+def get_file(*paths):
+    path = os.path.join(*paths)
     try:
         with open(path, 'rb') as f:
             return f.read().decode('utf8')
@@ -14,12 +15,30 @@ def readme():
         pass
 
 
+def get_version():
+    init_py = get_file(os.path.dirname(__file__), 'googletrans', '__init__.py')
+    pattern = r"{0}\W*=\W*'([^']+)'".format('__version__')
+    version, = re.findall(pattern, init_py)
+    return version
+
+
+def get_description():
+    init_py = get_file(os.path.dirname(__file__), 'googletrans', '__init__.py')
+    pattern = r'"""(.*?)"""'
+    description, = re.findall(pattern, init_py, re.DOTALL)
+    return description
+
+
+def get_readme():
+    return get_file(os.path.dirname(__file__), 'README.rst')
+
+
 def install():
     setup(
         name='googletrans',
-        version=googletrans.__version__,
-        description=googletrans.__doc__,
-        long_description=readme(),
+        version=get_version(),
+        description=get_description(),
+        long_description=get_readme(),
         license='MIT',
         author='SuHun Han',
         author_email='ssut' '@' 'ssut.me',


### PR DESCRIPTION
I propose to change the way of getting version number and doc string in setup.py, that we do not have to import __init__.py to setup.py.

In my fork, I create the way of getting version number without import another files of googletrans library. I open __init__.py file read it and get version and doc string with regex.
This method is used by many big libraries, ex. django-rest-framework.

@ssut please consider this solution, because it can help many people.