### PR TITLE
Support languages names and RFC 1766 codes

### DIFF
--- a/googletrans/__init__.py
+++ b/googletrans/__init__.py
@@ -4,4 +4,4 @@ __version__ = '2.1.3'
 
 
 from googletrans.client import Translator
-from googletrans.constants import LANGUAGES
+from googletrans.constants import LANGCODES, LANGUAGES

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -10,7 +10,7 @@ import random
 from googletrans import urls, utils
 from googletrans.compat import PY3
 from googletrans.gtoken import TokenAcquirer
-from googletrans.constants import DEFAULT_USER_AGENT, LANGUAGES, SPECIAL_CASES
+from googletrans.constants import DEFAULT_USER_AGENT, LANGCODES, LANGUAGES, SPECIAL_CASES
 from googletrans.models import Translated, Detected
 
 
@@ -50,19 +50,7 @@ class Translator(object):
             return self.service_urls[0]
         return random.choice(self.service_urls)
 
-    def _translate(self, text, dest='en', src='auto'):
-        if src != 'auto':
-            if src not in LANGUAGES.keys() and src in SPECIAL_CASES.keys():
-                src = SPECIAL_CASES[src]
-            elif src not in LANGUAGES.keys():
-                raise ValueError('invalid source language')
-
-        if dest not in LANGUAGES.keys():
-            if dest in SPECIAL_CASES.keys():
-                dest = SPECIAL_CASES[dest]
-            else:
-                raise ValueError('invalid destination language')
-
+    def _translate(self, text, dest, src):
         if not PY3 and isinstance(text, str):  # pragma: nocover
             text = text.decode('utf-8')
 
@@ -82,11 +70,13 @@ class Translator(object):
         :type text: UTF-8 :class:`str`; :class:`unicode`; string sequence (list, tuple, iterator, generator)
 
         :param dest: The language to translate the source text into.
-                     The value should be one of the language codes listed in :const:`googletrans.LANGUAGES`.
+                     The value should be one of the language codes listed in :const:`googletrans.LANGUAGES`
+                     or one of the language names listed in :const:`googletrans.LANGCODES`.
         :param dest: :class:`str`; :class:`unicode`
 
         :param src: The language of the source text.
-                    The value should be one of the language codes listed in :const:`googletrans.LANGUAGES`.
+                    The value should be one of the language codes listed in :const:`googletrans.LANGUAGES`
+                    or one of the language names listed in :const:`googletrans.LANGCODES`.
                     If a language is not specified,
                     the system will attempt to identify the source language automatically.
         :param src: :class:`str`; :class:`unicode`
@@ -112,6 +102,25 @@ class Translator(object):
             jumps over  ->  이상 점프
             the lazy dog  ->  게으른 개
         """
+        dest = dest.lower().split('_', 1)[0]
+        src = src.lower().split('_', 1)[0]
+
+        if src != 'auto' and src not in LANGUAGES:
+            if src in SPECIAL_CASES:
+                src = SPECIAL_CASES[src]
+            elif src in LANGCODES:
+                src = LANGCODES[src]
+            else:
+                raise ValueError('invalid source language')
+
+        if dest not in LANGUAGES:
+            if dest in SPECIAL_CASES:
+                dest = SPECIAL_CASES[dest]
+            elif dest in LANGCODES:
+                dest = LANGCODES[dest]
+            else:
+                raise ValueError('invalid destination language')
+
         if isinstance(text, list):
             result = []
             for item in text:

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -60,6 +60,5 @@ LANGUAGES = {
     'cy': 'welsh',
     'yi': 'yiddish',
   }
-  
-  LANGCODES = dict(map(reversed, LANGUAGES.items()))
-  
+
+LANGCODES = dict(map(reversed, LANGUAGES.items()))

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -60,3 +60,6 @@ LANGUAGES = {
     'cy': 'welsh',
     'yi': 'yiddish',
   }
+  
+  LANGCODES = dict(map(reversed, LANGUAGES.items()))
+  

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,16 @@ def test_unicode(translator):
     assert result.text == u'こんにちは。'
 
 
+def test_language_name(translator):
+    result = translator.translate(u'Hello', src='ENGLISH', dest='iRiSh')
+    assert result.text == u'Dia dhuit'
+
+
+def test_language_rfc1766(translator):
+    result = translator.translate(u'luna', src='it_ch@euro', dest='en')
+    assert result.text == u'moon'
+
+
 def test_special_chars(translator):
     text = u"©×《》"
 


### PR DESCRIPTION
Accept languages names (case-insensitive) as dest/src params in the `translate` routine.
Accept [RFC 1766](https://tools.ietf.org/html/rfc1766.html) codes (eg.: nl_nl, es_uy@euro, etc.) as well.
Move dest/src params check to the `translate` routine.
