### PR TITLE
add proxy support

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -28,10 +28,16 @@ class Translator(object):
 
     :param user_agent: the User-Agent header to send when making requests.
     :type user_agent: :class:`str`
+
+    :param proxies: proxies configuration. 
+                    Dictionary mapping protocol or protocol and host to the URL of the proxy 
+                    For example ``{'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}``
     """
 
-    def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT):
+    def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT, proxies=None):
         self.session = requests.Session()
+        if proxies is not None:
+            self.session.proxies = proxies
         self.session.headers.update({
             'User-Agent': user_agent,
         })


### PR DESCRIPTION
Hi, I have added a simple implementation for proxy support. I tested it with sock5 proxy.

```
In [1]: from googletrans import Translator

In [2]: socks5 = 'socks5://127.0.0.1'

In [3]: proxies = {'http': socks5, 'https': socks5}

In [4]: translator = Translator(proxies=proxies)

In [5]: result = translator.translate(u'안녕하세요.', dest='ja')

In [6]: assert result.pronunciation == 'Kon\'nichiwa.'

In [8]: print result.text
こんにちは。
```
