### PR TITLE
Filipino && Hebrew support

### DIFF
--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -108,7 +108,9 @@ LANGUAGES = {
     'xh': 'xhosa',
     'yi': 'yiddish',
     'yo': 'yoruba',
-    'zu': 'zulu'
+    'zu': 'zulu',
+    'fil': 'Filipino',
+    'he': 'Hebrew'
 }
 
 LANGCODES = dict(map(reversed, LANGUAGES.items()))


### PR DESCRIPTION
I'm developing Chrome Extension and make a batch to generate the locales, your py-googletrans save me a lot of time. Thank you.

But I find the language support is not complete, it show me invalid language detected, and I read your code and fix the error.

May this patch help others.