### PR TITLE
Add raise_exception option to Translator to add workaround for json.decoder.JSONDecodeError

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -10,7 +10,8 @@ import random
 from googletrans import urls, utils
 from googletrans.compat import PY3
 from googletrans.gtoken import TokenAcquirer
-from googletrans.constants import DEFAULT_USER_AGENT, LANGCODES, LANGUAGES, SPECIAL_CASES
+from googletrans.constants import DEFAULT_USER_AGENT, LANGCODES, LANGUAGES, SPECIAL_CASES, \
+    DEFAULT_RAISE_EXCEPTION, DUMMY_DATA
 from googletrans.models import Translated, Detected
 
 
@@ -29,20 +30,19 @@ class Translator(object):
     :param user_agent: the User-Agent header to send when making requests.
     :type user_agent: :class:`str`
 
-    :param proxies: proxies configuration. 
-                    Dictionary mapping protocol or protocol and host to the URL of the proxy 
-                    For example ``{'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}``
+    :param raise_exception: if `True` then raise exception if smth will go wrong
+    :type raise_exception: boolean
     """
 
-    def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT, proxies=None):
+    def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT,
+            raise_exception=DEFAULT_RAISE_EXCEPTION):
         self.session = requests.Session()
-        if proxies is not None:
-            self.session.proxies = proxies
         self.session.headers.update({
             'User-Agent': user_agent,
         })
         self.service_urls = service_urls or ['translate.google.com']
         self.token_acquirer = TokenAcquirer(session=self.session, host=self.service_urls[0])
+        self.raise_exception = raise_exception
 
         # Use HTTP2 Adapter if hyper is installed
         try:  # pragma: nocover
@@ -66,8 +66,14 @@ class Translator(object):
         url = urls.TRANSLATE.format(host=self._pick_service_url())
         r = self.session.get(url, params=params)
 
-        data = utils.format_json(r.text)
-        return data
+        if r.status_code == 200:
+            data = utils.format_json(r.text)
+            return data
+        else:
+            if self.raise_exception:
+                raise Exception('Unexpected status code "{}" from {}'.format(r.status_code, self.service_urls))
+            return DUMMY_DATA[0][0][0] = text
+
 
     def translate(self, text, dest='en', src='auto'):
         """Translate text from source language to destination language

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -35,7 +35,7 @@ class Translator(object):
     """
 
     def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT,
-            raise_exception=DEFAULT_RAISE_EXCEPTION):
+            raise_exception=DEFAULT_RAISE_EXCEPTION, proxies=None):
         self.session = requests.Session()
         self.session.headers.update({
             'User-Agent': user_agent,

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -72,7 +72,8 @@ class Translator(object):
         else:
             if self.raise_exception:
                 raise Exception('Unexpected status code "{}" from {}'.format(r.status_code, self.service_urls))
-            return DUMMY_DATA[0][0][0] = text
+            DUMMY_DATA[0][0][0] = text
+            return DUMMY_DATA
 
 
     def translate(self, text, dest='en', src='auto'):

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -114,3 +114,5 @@ LANGUAGES = {
 }
 
 LANGCODES = dict(map(reversed, LANGUAGES.items()))
+DEFAULT_RAISE_EXCEPTION = False
+DUMMY_DATA = [[["",None,None,0]],None,"en",None,None,None,1,None,[["en"],None,[1],["en"]]]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
+import sys
+if sys.version_info >= (3, 3):
+    from unittest.mock import patch
+else:
+    from mock import patch
 from pytest import raises
+
 from requests.exceptions import ConnectionError
 from requests.exceptions import ReadTimeout
+from requests import Session
 
 from googletrans import Translator
 
@@ -133,3 +140,15 @@ def test_read_timeout():
     with raises(ReadTimeout):
         translator = Translator(timeout=(10, 0.00001))
         translator.translate('안녕하세요.')
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.text = 'tkk:\'translation\''
+
+
+@patch.object(Session, 'get', return_value=MockResponse('403'))
+def test_403_error(session_mock):
+    translator = Translator()
+    assert translator.translate('test', dest='ko')

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=
     pytest
     pytest-capturelog
     pytest-cov
+    mock
 commands=
     py.test --cov-report= --cov={envsitepackagesdir}/googletrans {posargs:}
 


### PR DESCRIPTION
During translating google API can send you error page back. In my use case this was caused by russian text with emojies. I've this issue with chinese to english translation. Do not really know the underlying reason (I guess it's author's generated token -- cause I get 403 status code), but implement simple workaround for this.