### PR TITLE
Proxy verify support + fixes

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -38,20 +38,26 @@ class Translator(object):
     :param timeout: Definition of timeout for Requests library.
                     Will be used by every request.
     :type timeout: number or a double of numbers
+
+    :param verify: Cerfiticate path for SSL-enabled proxies.
+    :type verify: :class:`str`
     """
 
     def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT,
-                 proxies=None, timeout=None):
+                 proxies=None, timeout=None, verify=None):
 
         self.session = requests.Session()
-        if proxies is not None:
+        if proxies:
             self.session.proxies = proxies
         self.session.headers.update({
             'User-Agent': user_agent,
         })
-        if timeout is not None:
+        if timeout:
             self.session.mount('https://', TimeoutAdapter(timeout))
             self.session.mount('http://', TimeoutAdapter(timeout))
+
+        if verify:
+            self.session.verify = verify
 
         self.service_urls = service_urls or ['translate.google.com']
         self.token_acquirer = TokenAcquirer(session=self.session, host=self.service_urls[0])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
-requests==2.13.0
-future==0.14.3
 coveralls==1.1
+future==0.14.3
+requests==2.13.0
+pytest==4.4.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,11 +87,11 @@ def test_detect_list(translator):
 
 
 def test_src_in_special_cases(translator):
-    args = ('Tere', 'en', 'ee')
+    args = ('Kala', 'en', 'ee')
 
     result = translator.translate(*args)
 
-    assert result.text == 'Hello'
+    assert result.text == 'Fish'
 
 
 def test_src_not_in_supported_languages(translator):


### PR DESCRIPTION
Hi!

Nice job! Absolutely love your library. 

Lately i just needed to add `verify` param support for your implementation of requests.session.

```
from googletrans import Translator

verify = '/my/path/to/proxy.crt'

translator = Translator(proxies={'https': 'https://example.com/'}, verify=verify)
```

I want to share my experience and hope someone also needs that feature.

Also fixed some missing details. I added another dependencies in requirements files and fixed test for Estonian source language for the on of most common and definitive cases of bidirectional translate. I used word `Kala` for english `Fish` because pair of `Tere - Hello` not worked during the tests.
Thank you!