### PR TITLE
Add ability to pass translation api params dinamically

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -165,7 +165,7 @@ class Translator(object):
         if isinstance(text, list):
             result = []
             for item in text:
-                translated = self.translate(item, dest=dest, src=src)
+                translated = self.translate(item, dest=dest, src=src, **kwargs)
                 result.append(translated)
             return result
 

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -68,13 +68,14 @@ class Translator(object):
             return self.service_urls[0]
         return random.choice(self.service_urls)
 
-    def _translate(self, text, dest, src):
+    def _translate(self, text, dest, src, override):
         if not PY3 and isinstance(text, str):  # pragma: nocover
             text = text.decode('utf-8')
 
         token = self.token_acquirer.do(text)
         params = utils.build_params(query=text, src=src, dest=dest,
-                                    token=token)
+                                    token=token, override=override)
+
         url = urls.TRANSLATE.format(host=self._pick_service_url())
         r = self.session.get(url, params=params)
 
@@ -103,7 +104,7 @@ class Translator(object):
 
         return extra
 
-    def translate(self, text, dest='en', src='auto'):
+    def translate(self, text, dest='en', src='auto', **kwargs):
         """Translate text from source language to destination language
 
         :param text: The source text(s) to be translated. Batch translation is supported via sequence input.
@@ -169,7 +170,7 @@ class Translator(object):
             return result
 
         origin = text
-        data = self._translate(text, dest, src)
+        data = self._translate(text, dest, src, kwargs)
 
         # this code will be updated when the format is changed.
         translated = ''.join([d[0] if d[0] else '' for d in data[0]])
@@ -208,7 +209,7 @@ class Translator(object):
 
         return result
 
-    def detect(self, text):
+    def detect(self, text, **kwargs):
         """Detect language of the input text
 
         :param text: The source text(s) whose language you want to identify.
@@ -246,7 +247,7 @@ class Translator(object):
                 result.append(lang)
             return result
 
-        data = self._translate(text, dest='en', src='auto')
+        data = self._translate(text, 'en', 'auto', kwargs)
 
         # actual source language that will be recognized by Google Translator when the
         # src passed is equal to auto.

--- a/googletrans/gtoken.py
+++ b/googletrans/gtoken.py
@@ -161,7 +161,7 @@ class TokenAcquirer(object):
         # assume e means char code array
         e = []
         g = 0
-        size = len(text)
+        size = len(a)
         while g < size:
             l = a[g]
             # just append if l is less than 128(ascii: DEL)

--- a/googletrans/utils.py
+++ b/googletrans/utils.py
@@ -4,7 +4,7 @@ import re
 import json
 
 
-def build_params(query, src, dest, token):
+def build_params(query, src, dest, token, override):
     params = {
         'client': 'webapp',
         'sl': src,
@@ -19,6 +19,11 @@ def build_params(query, src, dest, token):
         'tk': token,
         'q': query,
     }
+
+    if override is not None:
+        for key, value in get_items(override):
+            params[key] = value
+
     return params
 
 
@@ -53,6 +58,11 @@ def legacy_format_json(original):
 
     converted = json.loads(text)
     return converted
+
+
+def get_items(dict_object):
+    for key in dict_object:
+        yield key, dict_object[key]
 
 
 def format_json(original):


### PR DESCRIPTION
With following PR (https://github.com/ssut/py-googletrans/pull/102) translation library started using different model on google side.

There is a difference on translation output based on `client='webapp'` and `client='t'`.
For example following text
`We will send your card to La Résidence du Cap, 83980 Le Lavandou, France.`
with `client='t'` translates to
`Vamos enviar o seu cartão para La Résidence du Cap, 83980 Le Lavandou, França.`

but with `client='webapp'` translates to
`Enviaremos seu cartão para La Résidence du Cap, 83980 Le Lavandou, França.`



Steps to reproduce
Just install `2.4.0` , try following, then install `2.4.1`  and repeat

```
from googletrans import Translator

tr = Translator()
print(tr.translate(text='We will send your card to La Résidence du Cap, 83980 Le Lavandou, France.', src='en', dest='pt'))
# outputs if 2.4.0
# 'Vamos enviar o seu cartão para La Résidence du Cap, 83980 Le Lavandou, França.'

# and if it's `2.4.1` it outputs 
# `Enviaremos seu cartão para La Résidence du Cap, 83980 Le Lavandou, França.`
```

Hence would be good to be able to pass different params to API, to have more control.