### PR TITLE
Add new languages rw, tt, tk and more special cases

### DIFF
--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -67,14 +67,18 @@ DEFAULT_SERVICE_URLS = ('translate.google.ac','translate.google.ad','translate.g
                         'translate.google.tk','translate.google.tl','translate.google.tm',
                         'translate.google.tn','translate.google.to','translate.google.tt',
                         'translate.google.us','translate.google.vg','translate.google.vu','translate.google.ws')
+
+# Map standard codes to Google codes
 SPECIAL_CASES = {
-    'ee': 'et',
+    # Where Google uses a nonstandard legacy language code
     'jv': 'jw',
     'he': 'iw',
-    'nb': 'no',
-    'fil': 'tl',
-    'hmn': 'mww',
-    'in': 'id'
+    'id': 'in'
+    # Macrolanguages where Google uses the code of specific variant
+    'no': 'nb',
+    'tl': 'fil',
+    # Specific variants where Google uses the code of macrolanguage
+    'mww': 'hmn',
 }
 
 LANGUAGES = {

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -110,6 +110,7 @@ LANGUAGES = {
     'en': 'english',
     'eo': 'esperanto',
     'et': 'estonian',
+    'tl': 'filipino', # or 'tagalog'
     'fi': 'finnish',
     'fr': 'french',
     'fy': 'frisian',
@@ -178,7 +179,6 @@ LANGUAGES = {
     'sw': 'swahili',
     'sv': 'swedish',
     'tg': 'tajik',
-    'tl': 'tagalog',
     'ta': 'tamil',
     'tt': 'tatar',
     'te': 'telugu',

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -69,6 +69,12 @@ DEFAULT_SERVICE_URLS = ('translate.google.ac','translate.google.ad','translate.g
                         'translate.google.us','translate.google.vg','translate.google.vu','translate.google.ws')
 SPECIAL_CASES = {
     'ee': 'et',
+    'jv': 'jw',
+    'he': 'iw',
+    'nb': 'no',
+    'fil': 'tl',
+    'hmn': 'mww',
+    'in': 'id'
 }
 
 LANGUAGES = {
@@ -120,6 +126,7 @@ LANGUAGES = {
     'it': 'italian',
     'ja': 'japanese',
     'jw': 'javanese',
+    'rw': 'kinyarwanda',
     'kn': 'kannada',
     'kk': 'kazakh',
     'km': 'khmer',
@@ -166,9 +173,11 @@ LANGUAGES = {
     'sv': 'swedish',
     'tg': 'tajik',
     'ta': 'tamil',
+    'tt': 'tatar',
     'te': 'telugu',
     'th': 'thai',
     'tr': 'turkish',
+    'tk': 'turkmen'
     'uk': 'ukrainian',
     'ur': 'urdu',
     'ug': 'uyghur',

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -70,11 +70,13 @@ DEFAULT_SERVICE_URLS = ('translate.google.ac','translate.google.ad','translate.g
 
 # Map standard or de facto codes to Google codes
 SPECIAL_CASES = {
-    # Where Google used to require a nonstandard legacy language code
+    # Where Google used to require a legacy language code
     'jv': 'jw',
-    # Where Google previously required a nonstandard legacy language code, so some clients may still be sending it
+    # Where Google previously required a legacy language code, so some clients may still be sending it
     'iw': 'he',
     'in': 'id'
+    # Where Google previously required an incorrect language code, so some clients may still be sending it
+    'ee': 'et',
     # Specific variants where Google requires the code of the macrolanguage
     'mww': 'hmn',
     'nb': 'no',

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -68,17 +68,19 @@ DEFAULT_SERVICE_URLS = ('translate.google.ac','translate.google.ad','translate.g
                         'translate.google.tn','translate.google.to','translate.google.tt',
                         'translate.google.us','translate.google.vg','translate.google.vu','translate.google.ws')
 
-# Map standard codes to Google codes
+# Map standard or de facto codes to Google codes
 SPECIAL_CASES = {
-    # Where Google uses a nonstandard legacy language code
+    # Where Google used to require a nonstandard legacy language code
     'jv': 'jw',
-    'he': 'iw',
-    'id': 'in'
-    # Macrolanguages where Google uses the code of specific variant
-    'no': 'nb',
-    'tl': 'fil',
-    # Specific variants where Google uses the code of macrolanguage
+    # Where Google previously required a nonstandard legacy language code, so some clients may still be sending it
+    'iw': 'he',
+    'in': 'id'
+    # Specific variants where Google requires the code of the macrolanguage
     'mww': 'hmn',
+    'nb': 'no',
+    # Specific variants where Google previously required the code of the macrolanguage, so some clients may still be sending it
+    'fil': 'tl',
+    # Macrolanguages where Google requires the code of specific variant
 }
 
 LANGUAGES = {
@@ -106,7 +108,6 @@ LANGUAGES = {
     'en': 'english',
     'eo': 'esperanto',
     'et': 'estonian',
-    'tl': 'filipino',
     'fi': 'finnish',
     'fr': 'french',
     'fy': 'frisian',
@@ -118,7 +119,6 @@ LANGUAGES = {
     'ht': 'haitian creole',
     'ha': 'hausa',
     'haw': 'hawaiian',
-    'iw': 'hebrew',
     'he': 'hebrew',
     'hi': 'hindi',
     'hmn': 'hmong',
@@ -176,6 +176,7 @@ LANGUAGES = {
     'sw': 'swahili',
     'sv': 'swedish',
     'tg': 'tajik',
+    'tl': 'tagalog',
     'ta': 'tamil',
     'tt': 'tatar',
     'te': 'telugu',


### PR DESCRIPTION
Add rw (Kinyarwanda), tt (Tatar), tk (Turkmen)

I think we can remove
```
    'ee': 'et',
```
from `SPECIAL_CASES`, as `et` is totally standard.

Rather, we should add deduplicate Hebrew, as `iw` is non-standard.
