### PR TITLE
enhancement: Turn off Strict SSL verification

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,6 +1,6 @@
 [[source]]
 url = "https://pypi.python.org/simple"
-verify_ssl = true
+verify_ssl = false
 name = "pypi"
 
 [packages]

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Features
 -  Bulk translations
 -  Customizable service URL
 -  HTTP/2 support
+-  verify support to turn off/on strict SSL
 
 TODO
 ~~~~
@@ -103,6 +104,16 @@ URLs are provided, it then randomly chooses a domain.
           'translate.google.com',
           'translate.google.co.kr',
         ])
+
+Turn off Strict ssl
+~~~~~~~~~~~~~~~~~~~~~
+
+use verify either to turn OFF or ON strict SSL. Default will be turned on
+
+.. code:: python
+
+    >>> from googletrans import Translator
+    >>> translator = Translator(verify=False)
 
 Advanced Usage (Bulk)
 ~~~~~~~~~~~~~~~~~~~~~

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -9,6 +9,7 @@ import typing
 
 import httpcore
 import httpx
+import ssl
 from httpx import Timeout
 
 from googletrans import urls, utils
@@ -55,7 +56,7 @@ class Translator:
                  timeout: Timeout = None,
                  http2=True):
 
-        self.client = httpx.Client(http2=http2)
+        self.client = httpx.Client(http2=http2, verify=False)
         if proxies is not None:  # pragma: nocover
             self.client.proxies = proxies
 

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -46,6 +46,8 @@ class Translator:
     :param proxies: proxies configuration.
                     Dictionary mapping protocol or protocol and host to the URL of the proxy
                     For example ``{'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}``
+    :param verify: certificate configuration.
+                   or example ``False`` or ``'\tmp/cacert.pem'``
     :param raise_exception: if `True` then raise exception if smth will go wrong
     :type raise_exception: boolean
     """
@@ -54,9 +56,9 @@ class Translator:
                  raise_exception=DEFAULT_RAISE_EXCEPTION,
                  proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = None,
                  timeout: Timeout = None,
-                 http2=True):
+                 http2=True, verify=True):
 
-        self.client = httpx.Client(http2=http2, verify=False)
+        self.client = httpx.Client(http2=http2, verify=verify)
         if proxies is not None:  # pragma: nocover
             self.client.proxies = proxies
 
@@ -69,7 +71,7 @@ class Translator:
 
         self.service_urls = service_urls or ['translate.google.com']
         self.token_acquirer = TokenAcquirer(
-            client=self.client, host=self.service_urls[0])
+            client=self.client, host=self.service_urls[0], verify=verify)
         self.raise_exception = raise_exception
 
     def _pick_service_url(self):

--- a/googletrans/gtoken.py
+++ b/googletrans/gtoken.py
@@ -5,7 +5,7 @@ import re
 import time
 
 import httpx
-
+import ssl
 from googletrans.utils import rshift
 
 
@@ -23,7 +23,7 @@ class TokenAcquirer:
     token (e.g. 744915.856682) which is used by the API to validate the
     request.
 
-    This operation will cause an additional request to get an initial
+    This operation will cause an additional possible to get an initial
     token from translate.google.com.
 
     Example usage:
@@ -38,7 +38,7 @@ class TokenAcquirer:
     RE_TKK = re.compile(r'tkk:\'(.+?)\'', re.DOTALL)
     RE_RAWTKK = re.compile(r'tkk:\'(.+?)\'', re.DOTALL)
 
-    def __init__(self, client: httpx.Client, tkk='0', host='translate.google.com'):
+    def __init__(self, client: httpx.Client(verify=False), tkk='0', host='translate.google.com'):
         self.client = client
         self.tkk = tkk
         self.host = host if 'http' in host else 'https://' + host

--- a/googletrans/gtoken.py
+++ b/googletrans/gtoken.py
@@ -38,7 +38,8 @@ class TokenAcquirer:
     RE_TKK = re.compile(r'tkk:\'(.+?)\'', re.DOTALL)
     RE_RAWTKK = re.compile(r'tkk:\'(.+?)\'', re.DOTALL)
 
-    def __init__(self, client: httpx.Client(verify=False), tkk='0', host='translate.google.com'):
+    def __init__(self, client: httpx.Client, tkk='0', host='translate.google.com', verify= True):
+        client.verify = verify;
         self.client = client
         self.tkk = tkk
         self.host = host if 'http' in host else 'https://' + host


### PR DESCRIPTION
Most of the users were facing the below error due to strict SSL verification by default turned on. Now users have the option to turn it off or on or specify the path for certificate. 

ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)