### PR TITLE
Feature/enhance use of direct api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,21 @@ URLs are provided, it then randomly chooses a domain.
           'translate.google.co.kr',
         ])
 
+Customize service URL to point to standard api
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Considering translate.google.<domain> url services use the webapp requiring a token, 
+you can prefer to use the direct api than does not need any token to process.
+It can solve your problems of unstable token providing processes (refer to issue #234)
+
+.. code:: python
+
+    >>> from googletrans import Translator
+    >>> translator = Translator(service_urls=[
+          'translate.googleapis.com'
+        ])
+
+
 Advanced Usage (Bulk)
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/googletrans/utils.py
+++ b/googletrans/utils.py
@@ -3,9 +3,9 @@ import json
 import re
 
 
-def build_params(query, src, dest, token, override):
+def build_params(client,query, src, dest, token, override):
     params = {
-        'client': 'webapp',
+        'client': client,
         'sl': src,
         'tl': dest,
         'hl': dest,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,15 @@ def test_bind_multiple_service_urls():
     assert translator.translate('test', dest='ko')
     assert translator.detect('Hello')
 
+def test_api_service_urls():
+    service_urls = ['translate.googleapis.com']
+
+    translator = Translator(service_urls=service_urls)
+    assert translator.service_urls == service_urls
+
+    assert translator.translate('test', dest='ko')
+    assert translator.detect('Hello')
+
 
 def test_source_language(translator):
     result = translator.translate('안녕하세요.')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ def test_rshift():
 
 def test_build_params_with_override():
     params = utils.build_params(
+        client='',
         query='',
         src='',
         dest='',


### PR DESCRIPTION
In a perspective to help solving issue #234 I propose a solution that implements a proper way to use translate.googleapis.com as url service.
This url service has following characteristics: 
- no need for a token
- uses client gtx instead of webapp
I made a few modifications to mainly deal with these characteristics, preserving the possibility to use standard webapp calls.
The client should use 'translate.googleapis.com' as service url when instanciating Translator() object, adapted code will manage the valuation of client gtx in utils params.
Looking forward to reading your remarks for improvement is needed before final merge.