### PR TITLE
Fix translate_legacy

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -328,7 +328,7 @@ class Translator:
             return result
 
         origin = text
-        data, response = self._translate_legacy(text, dest, src)
+        data, response = self._translate_legacy(text, dest, src, kwargs)
 
         # this code will be updated when the format is changed.
         translated = ''.join([d[0] if d[0] else '' for d in data[0]])
@@ -361,7 +361,7 @@ class Translator:
         result = Translated(src=src, dest=dest, origin=origin,
                             text=translated, pronunciation=pron,
                             extra_data=extra_data,
-                            response=response)
+                            response=response, parts=None)
 
         return result
 

--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -328,7 +328,7 @@ class Translator:
             return result
 
         origin = text
-        data, response = self.translate_legacy(text, dest, src)
+        data, response = self._translate_legacy(text, dest, src)
 
         # this code will be updated when the format is changed.
         translated = ''.join([d[0] if d[0] else '' for d in data[0]])


### PR DESCRIPTION
`translate_legacy` was broken, so there was no possibility to fallback when issues like #257 happens. This fixes the said issue.