### PR TITLE
Correcting proxy settings for googletrans

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -51,13 +51,11 @@ class Translator:
 
     def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT,
                  raise_exception=DEFAULT_RAISE_EXCEPTION,
-                 proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = None,
+                 proxies: typing.Dict[str, str] = None,
                  timeout: Timeout = None,
                  http2=True):
 
-        self.client = httpx.Client(http2=http2)
-        if proxies is not None:  # pragma: nocover
-            self.client.proxies = proxies
+        self.client = httpx.Client(http2=http2, proxies=proxies)
 
         self.client.headers.update({
             'User-Agent': user_agent,


### PR DESCRIPTION
This module in its current form is completely impossible to configure to work with a proxy. There is an error in the constructor itself `self.client.proxies = proxies` that will not work in any way.

I made few changes in **client.py**, now its look like this:
```python
def __init__(self, service_urls=DEFAULT_CLIENT_SERVICE_URLS, user_agent=DEFAULT_USER_AGENT,
             raise_exception=DEFAULT_RAISE_EXCEPTION,
             proxies: typing.Dict[str, str] = None,
             timeout: Timeout = None,
             http2=True,
             use_fallback=False):

    self.client = httpx.Client(http2=http2, proxies=proxies)
```
Usage:
```python
from googletrans import Translator
from httpx import Timeout

proxy = {
        'http': 'http://username:password@1.1.1.1:1234',
        'https': 'http://username:password@1.1.1.1:1234',
}

translator = Translator(proxies=proxy, timeout=Timeout(120))
data = translator.translate(
    'Hello, World!', src='en', dest='ru'
)

print(data)
```