### PR TITLE
docs: fix simple typo, wiered -> weird

### DIFF
--- a/googletrans/utils.py
+++ b/googletrans/utils.py
@@ -39,7 +39,7 @@ def legacy_format_json(original):
             nxt = text.find('"', p)
             states.append((p, text[p:nxt]))
 
-    # replace all wiered characters in text
+    # replace all weird characters in text
     while text.find(',,') > -1:
         text = text.replace(',,', ',null,')
     while text.find('[,') > -1:


### PR DESCRIPTION
There is a small typo in googletrans/utils.py.

Should read `weird` rather than `wiered`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md