### PR TITLE
remove legacy httpx library typing code

### DIFF
--- a/googletrans/client.py
+++ b/googletrans/client.py
@@ -51,7 +51,7 @@ class Translator:
 
     def __init__(self, service_urls=None, user_agent=DEFAULT_USER_AGENT,
                  raise_exception=DEFAULT_RAISE_EXCEPTION,
-                 proxies: typing.Dict[str, httpcore.SyncHTTPTransport] = None,
+                 proxies = None,
                  timeout: Timeout = None,
                  http2=True):
 


### PR DESCRIPTION
remove deprecated typing info about httpx==0.13.3
(https://github.com/ssut/py-googletrans/issues/380)