### PR TITLE
added oromo language into LANGUAGES list

### DIFF
--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -143,6 +143,10 @@ LANGUAGES = {
     'my': 'myanmar (burmese)',
     'ne': 'nepali',
     'no': 'norwegian',
+    # added this line
+    #############
+    'om': 'oromo',
+    #############
     'or': 'odia',
     'ps': 'pashto',
     'fa': 'persian',

--- a/tests/eng_to_om.py
+++ b/tests/eng_to_om.py
@@ -1,0 +1,5 @@
+from googletrans import Translator
+translator = Translator()
+
+translation = translator.translate("hi" ,'om')
+print(translation.text)


### PR DESCRIPTION
it was not possible to translate from english to oromo because oromo language code was not added into the languages list so i have added it's code with it's name next to odia in line 149

you can try it out by doing this
- first go to test 
- and you will find eng_to_om.py