### PR TITLE
Bug fixed `AttributeError` in `RE_TKK.search`

### DIFF
--- a/googletrans/gtoken.py
+++ b/googletrans/gtoken.py
@@ -57,12 +57,15 @@ class TokenAcquirer:
         if raw_tkk:
             self.tkk = raw_tkk.group(1)
             return
+        
+        code = self.RE_TKK.search(r.text)
 
-        # this will be the same as python code after stripping out a reserved word 'var'
-        code = self.RE_TKK.search(r.text).group(1).replace('var ', '')
-        # unescape special ascii characters such like a \x3d(=)
-        code = code.encode().decode('unicode-escape')
-
+        if code is not None:
+            # this will be the same as python code after stripping out a reserved word 'var'
+            code = code.group(1).replace('var ', '')
+            # unescape special ascii characters such like a \x3d(=)
+            code = code.encode().decode('unicode-escape')
+            
         if code:
             tree = ast.parse(code)
             visit_return = False


### PR DESCRIPTION
no match was found for the regular expression `RE_TKK` in the text `r.text`.
```
    self._update()
    code = self.RE_TKK.search(r.text).group(1).replace('var ', '')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```

a check was added to handle this case.

```python
        code = self.RE_TKK.search(r.text)

        if code is not None:
            # this will be the same as python code after stripping out a reserved word 'var'
            code = code.group(1).replace('var ', '')
            # unescape special ascii characters such like a \x3d(=)
            code = code.encode().decode('unicode-escape')
```
the `AttributeError` error is avoided. In case you do not find a match