### PR TITLE
Add Kurdish (Sorani) to the language list.

### DIFF
--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -126,6 +126,7 @@ LANGUAGES = {
     'km': 'khmer',
     'ko': 'korean',
     'ku': 'kurdish (kurmanji)',
+    'ckb': 'kurdish (sorani)',
     'ky': 'kyrgyz',
     'lo': 'lao',
     'la': 'latin',


### PR DESCRIPTION
Add Kurdish (Sorani) aka Central Kurdish to the list of supported languages by Google translate.

Sorani Kurdish was added to the list since 2022 Google/IO

Source: [Google Translate learns 24 new languages](https://blog.google/products/translate/24-new-languages/)