### PR TITLE
Correct ber-atn to ber-latn

### DIFF
--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -417,7 +417,7 @@ LANGUAGES = {
     "tl": "tagalog (filipino)",
     "tah": "tahitian",
     "tg": "tajik",
-    "ber-Latn": "tamazight",
+    "ber-latn": "tamazight",
     "ber": "tamazight (tifinagh)",
     "ta": "tamil",
     "tt": "tatar",

--- a/googletrans/constants.py
+++ b/googletrans/constants.py
@@ -417,7 +417,7 @@ LANGUAGES = {
     "tl": "tagalog (filipino)",
     "tah": "tahitian",
     "tg": "tajik",
-    "ber-atn": "tamazight",
+    "ber-Latn": "tamazight",
     "ber": "tamazight (tifinagh)",
     "ta": "tamil",
     "tt": "tatar",


### PR DESCRIPTION
Hi,

Please correct `ber-atn` to `ber-Latn` on constants.py

Thank you.